### PR TITLE
feat: add .claude-plugin manifest for plugin management

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,21 @@
+{
+  "name": "khazix-skills",
+  "owner": {
+    "name": "KKKKhazix"
+  },
+  "metadata": {
+    "description": "数字生命卡兹克开源的 AI Skills 合集 — 公众号长文写作与内容创作",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "khazix-skills",
+      "description": "卡兹克公众号长文写作skill，包含写作风格规则、四层自检体系、内容方法论和风格示例库",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./khazix-writer"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `.claude-plugin/marketplace.json` to enable Claude Code plugin discovery and auto-update support for khazix-skills

This registers `khazix-writer` as a plugin entry so that users who install khazix-skills through the Claude Code plugin system can receive updates automatically when the skill is improved or new skills are added.

## Why a plugin manifest?

Claude Code's plugin system (`/.claude-plugin/marketplace.json`) provides:

1. **Auto-updates** — users stay current with skill improvements without needing to re-clone or manually sync
2. **Structured discovery** — Claude Code can read the manifest to understand what skills are available and how they're organized
3. **Version tracking** — the `version` field lets users and tooling know when meaningful changes have shipped

The manifest is lightweight (one JSON file) and does not change any existing functionality.

## Test plan

- [ ] Verify `.claude-plugin/marketplace.json` is valid JSON
- [ ] Confirm `khazix-writer` skill path resolves to the existing directory
- [ ] Confirm Claude Code recognizes the manifest when installed as a plugin