### PR TITLE
neat-freak: 加一步「提交并询问是否 push」收尾

### DIFF
--- a/neat-freak/SKILL.md
+++ b/neat-freak/SKILL.md
@@ -142,6 +142,41 @@ API 速查表、环境变量表、术语表是高频查询的结构化信息，*
 
 只列有实际变更的条目。没改的不写。
 
+### 第六步：提交（可选推送）
+
+知识同步本身就是一次"代码变更"——下一个 agent / 同事看到的是你**落盘**的版本，不是文件系统的中间态。让每次 sync 都留下时间戳和 diff，别让"我刚改了什么"只活在对话里。
+
+**按仓库分别处理，每个仓库一次提交**：
+
+1. 列出这次 skill 实际修改 / 新建 / 删除的文件，按仓库分组（一个项目仓库 + 可能的全局配置仓库 + 可能的 agent 记忆仓库）。
+2. 对每个仓库：
+   - 如果不是 git 仓库（`git rev-parse --git-dir` 失败），跳过，在结尾列出"未提交：<路径>（不是 git 仓库）"。
+   - **只 stage 你这次改的文件**——不要 `git add -A`，不要带上仓库里已有的脏改动。
+   - commit message 格式：`docs(sync): knowledge cleanup <YYYY-MM-DD>`，body 是该仓库的变更摘要。
+   - 如果你的改动文件跟已有脏改动有重叠，**停下来报告给用户**，不要强行 commit。
+3. **commit 完才询问 push**——commit 是本地动作，push 是仓库外可见的动作，两步分开：
+
+   ```
+   ## 已提交
+   - <repo-A> a1b2c3d — 同步 X / Y
+   - <repo-B> e4f5g6h — 更新 docs/architecture.md
+   未提交：~/.claude/projects/<...>/memory/（不在 git 仓库内）
+
+   要 push 哪些？
+     [a] <repo-A> only
+     [b] <repo-B> only
+     [c] 全部
+     [d] 都不 push
+   ```
+
+   **默认不 push**——push 是外部可见的动作，必须用户明确同意（`[c]` 或 `[a]/[b]`）。
+
+**特例 — 全局配置**（`~/.claude/CLAUDE.md`、`~/.codex/AGENTS.md` 等）：只在用户明确把它纳入版本控制时才 commit；否则只编辑文件，不 commit、不 push。
+
+**特例 — agent 记忆系统**：Claude Code 的 `~/.claude/projects/<...>/memory/` 默认不在 git 仓库里，按"未提交"列出即可，**不要**主动 `git init`。
+
+**Pre-existing 脏改动**：如果项目仓库里有这次 skill 没碰过的脏文件，**不要**打包进 sync commit。在摘要里 flag 一句"该仓库另有 N 个未提交改动，你自己看"，让用户自行处理。
+
 ## 特殊情况
 
 **项目还没有 README 或 CLAUDE.md/AGENTS.md**：判断项目是不是到了"有可运行代码"的阶段。是 → 创建。还在 vibe 阶段 → 跳过，但在摘要里提一句。


### PR DESCRIPTION
## 背景

跑完 `/neat` 之后，docs 和记忆改完了，但所有改动还躺在 working tree 里。要么用户记得自己 `git add` + commit，要么这次 sync 就没留下时间戳，下次 `git log` 看到的还是改之前的世界。

我自己用了一段时间，发现每次都要手动收尾这一步挺啰嗦，干脆让 skill 自己做完。

## 改动

`SKILL.md` 加一节 **第六步：提交（可选推送）**，放在「第五步：变更摘要」和「## 特殊情况」之间。

行为：

- **一个仓库一次 commit**，scope 仅限这次 skill 实际改过的文件。不 `git add -A`，不打包既有脏改动。
- Commit message 格式：`docs(sync): knowledge cleanup <YYYY-MM-DD>`，body 复用 Step 5 里该仓库的变更摘要。
- **commit 跟 push 分开**。commit 完之后用 `[a]` / `[b]` / `[c]` / `[d]` 让用户挑哪些仓库要 push。默认不 push，毕竟 push 是仓库外可见的动作。
- 非 git 路径（最常见就是 Claude Code 的 `~/.claude/projects/<...>/memory/`）按"未提交：<路径>（不是 git 仓库）"列出，**不**主动 `git init`。
- 全局配置（`~/.claude/CLAUDE.md`、`~/.codex/AGENTS.md`）默认只编辑、不 commit、不 push，除非用户已经把它纳入版本控制。
- Pre-existing 脏改动 flag 出来让用户自己处理，不打包进 sync commit。

## 设计取舍

- **粒度**：试过按文档/记忆/CLAUDE.md 分开 commit，太碎；一个 repo 一个 commit 最干净，commit message 的 body 已经能区分各类。
- **询问 push 用 `[a/b/c/d]` 而不是自然语言**：明确、可数；多 repo 时也好选。
- **默认不 push**：跟 skill 整体保守的语气一致。push 是 side-effect，必须用户明确同意。

## 兼容性

向后兼容。没改前五步任何逻辑，Step 6 只在 Step 1-3 实际产生了文件变更时才有意义；如果对话没有产生新事实（已经在「特殊情况」里覆盖），Step 6 自然没东西可 commit。

🤖 Generated with [Claude Code](https://claude.com/claude-code)